### PR TITLE
Corrected default min/max pulse_width defaults set in output_devices.rs

### DIFF
--- a/src/output_devices.rs
+++ b/src/output_devices.rs
@@ -679,8 +679,8 @@ impl Servo {
                 Err(e) => panic!("{:?}", e),
                 Ok(pin) => Servo {
                     pin: pin.into_io(Mode::Output),
-                    min_pulse_width: 1000,
-                    max_pulse_width: 2000,
+                    min_pulse_width: 1,
+                    max_pulse_width: 2,
                     frame_width: 20,
                 },
             },


### PR DESCRIPTION
The default min and max pulse widths were initially set to 1000 and 2000 milliseconds. This has been corrected to be 1 and 2 milliseconds (as per the original Python GPIO Zero library, see: https://gpiozero.readthedocs.io/en/stable/_modules/gpiozero/output_devices.html