### PR TITLE
Add fix for comparing max_pulse_width to frame_width

### DIFF
--- a/src/output_devices.rs
+++ b/src/output_devices.rs
@@ -741,7 +741,7 @@ impl Servo {
     }
     /// Set the servo's maximum pulse width
     pub fn set_max_pulse_width(&mut self, value: u64) {
-        if value >= self.frame_width {
+        if value >= self.frame_width * 1000 {
             println!("max_pulse_width must be less than frame_width");
             return;
         } else {


### PR DESCRIPTION
This comparison is causing `set_max_pulse_width()` to fail because we are comparing microseconds to milliseconds. Converting frame_width to microeconds allows us to make a realistic comparison. See #9 for the original issue report.