### PR TITLE
Implementing debounce for Button interrupts (sync & async)

### DIFF
--- a/examples/button_async.rs
+++ b/examples/button_async.rs
@@ -8,6 +8,10 @@ fn main() {
         // Add debouncing so that subsequent presses within 100ms don't trigger a press
         .debounce(Duration::from_millis(100));
 
-    button.wait_for_press(None);
-    println!("button pressed");
+    // Add an async interrupt to trigger whenever the button is pressed
+    button
+        .when_pressed(|_| {
+            println!("button pressed");
+        })
+        .unwrap();
 }

--- a/src/debounce.rs
+++ b/src/debounce.rs
@@ -1,0 +1,155 @@
+use std::fmt;
+use std::ops::{Deref, DerefMut};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use crate::Button;
+use rppal::gpio::{self, Level, Trigger};
+
+/// Adds `.debounce()` method to [`Button`] for converting to a [`Debounced`] button
+pub trait Debounce {
+    fn debounce(self, duration: Duration) -> Debounced;
+}
+
+impl Debounce for Button {
+    fn debounce(self, duration: Duration) -> Debounced {
+        Debounced {
+            inner: self,
+            period: duration,
+            last_trigger: Arc::new(Mutex::new(None)),
+        }
+    }
+}
+
+/// Wrapper type for [`Button`] to allow for software [debouncing](https://en.wikipedia.org/wiki/Switch#Contact%20Bounce). Will prevent
+/// Subsequent triggers with the given debounce period (E.g. 50-100 milliseconds)
+///
+/// Can be used with blocking functions (E.g [`Button::wait_for_press`]):
+/// ```
+/// use rust_gpiozero::{Button, Debounce};
+/// use std::time::Duration;
+///
+/// // Create a button which is attached to Pin 17
+/// let mut button = Button::new(17)
+///     // Add debouncing so that subsequent presses within 100ms don't trigger a press
+///     .debounce(Duration::from_millis(100));
+///
+/// button.wait_for_press(None);
+/// println!("button pressed");
+/// ```
+///
+/// Or async interrupt functions (E.g. [`Button::when_pressed`]):
+/// ```
+/// use rust_gpiozero::{Button, Debounce};
+/// use std::time::Duration;
+///
+/// // Create a button which is attached to Pin 17
+/// let mut button = Button::new(17)
+///     // Add debouncing so that subsequent presses within 100ms don't trigger a press
+///     .debounce(Duration::from_millis(100));
+///
+/// // Add an async interrupt to trigger whenever the button is pressed
+/// button.when_pressed(|_| {
+///     println!("button pressed");
+/// }).unwrap();
+/// ```
+
+pub struct Debounced {
+    inner: Button,
+    period: Duration,
+    last_trigger: Arc<Mutex<Option<Instant>>>,
+}
+
+impl fmt::Debug for Debounced {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Debounced")
+            .field("pin", &self.inner.pin())
+            .field("period", &self.period)
+            .finish()
+    }
+}
+
+impl Debounced {
+    /// Pause the program until the device is deactivated, or the timeout is reached.
+    /// * `timeout` - Number of seconds to wait before proceeding. If this is None, then wait indefinitely until the device is inactive.
+    pub fn wait_for_release(&mut self, timeout: Option<f32>) {
+        Debounced::wait_for(self, timeout, false)
+    }
+
+    /// Pause the program until the device is activated, or the timeout is reached.
+    /// * `timeout` - Number of seconds to wait before proceeding. If this is None, then wait indefinitely until the device is active.
+    pub fn wait_for_press(&mut self, timeout: Option<f32>) {
+        Debounced::wait_for(self, timeout, true)
+    }
+
+    fn wait_for(&mut self, timeout: Option<f32>, active: bool) {
+        let trigger = match active {
+            true => Trigger::RisingEdge,
+            false => Trigger::FallingEdge,
+        };
+        let timeout = timeout.map(|seconds| Duration::from_millis((seconds * 1000.0) as u64));
+        self.inner.pin.set_interrupt(trigger).unwrap();
+        loop {
+            self.inner.pin.poll_interrupt(true, timeout).unwrap();
+            // Check that enough time has passed since the last press
+            if let Some(last_trigger) = self.last_trigger.lock().unwrap().as_ref() {
+                // If this press is within the debounce time, continue blocking until the next press
+                if last_trigger.elapsed() < self.period {
+                    continue;
+                }
+            }
+            // if self.last_trigger is not set, there have been no previous presses so debounce time doesn't matter
+            break;
+        }
+        self.last_trigger.lock().unwrap().replace(Instant::now());
+    }
+
+    /// Asynchronously invokes the passed closure everytime the button is pressed, if the debounce period has passed
+    pub fn when_pressed<C>(&mut self, action: C) -> Result<(), gpio::Error>
+    where
+        C: FnMut(Level) + Send + 'static,
+    {
+        self.action_on(true, action)
+    }
+
+    /// Asynchronously invokes the passed closure everytime the button is released, if the debounce period has passed
+    pub fn when_released<C>(&mut self, action: C) -> Result<(), gpio::Error>
+    where
+        C: FnMut(Level) + Send + 'static,
+    {
+        self.action_on(false, action)
+    }
+
+    pub(crate) fn action_on<C>(&mut self, active: bool, mut action: C) -> Result<(), gpio::Error>
+    where
+        C: FnMut(Level) + Send + 'static,
+    {
+        let period = self.period;
+        let last_trigger = self.last_trigger.clone();
+        self.inner.action_on(active, move |level| {
+            let mut lt = last_trigger.lock().unwrap();
+            if let Some(last) = lt.as_ref() {
+                if last.elapsed() < period {
+                    // Within debounce period, don't execute action
+                    return;
+                }
+            }
+            lt.replace(Instant::now());
+            action(level);
+        })
+    }
+}
+
+impl Deref for Debounced {
+    type Target = Button;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl DerefMut for Debounced {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}

--- a/src/input_devices.rs
+++ b/src/input_devices.rs
@@ -1,5 +1,5 @@
 //! Input device component interfaces for devices such as `Button`
-use rppal::gpio::{Gpio, InputPin, Level, Trigger};
+use rppal::gpio::{self, Gpio, InputPin, Level, Trigger};
 use std::time::Duration;
 
 /// Represents a generic GPIO input device.
@@ -17,7 +17,7 @@ impl InputDevice {
     /// # Arguments
     ///
     /// * `pin` - The GPIO pin which the device is attached to
-    ///  
+    ///
     pub fn new(pin: u8) -> InputDevice {
         match Gpio::new() {
             Err(e) => panic!("{:?}", e),
@@ -37,7 +37,7 @@ impl InputDevice {
     /// # Arguments
     ///
     /// * `pin` - The GPIO pin which the device is attached to
-    ///  
+    ///
     pub fn new_with_pullup(pin: u8) -> InputDevice {
         match Gpio::new() {
             Err(e) => panic!("{:?}", e),
@@ -61,30 +61,13 @@ macro_rules! impl_events_mixin {
     () => {
         /// Pause the program until the device is activated, or the timeout is reached.
         fn wait_for(&mut self, timeout: Option<f32>, active: bool) {
-            match timeout {
-                None => {
-                    if active {
-                        self.pin.set_interrupt(Trigger::RisingEdge).unwrap();
-                        self.pin.poll_interrupt(true, None).unwrap();
-                    } else {
-                        self.pin.set_interrupt(Trigger::FallingEdge).unwrap();
-                        self.pin.poll_interrupt(true, None).unwrap();
-                    }
-                }
-                Some(n) => {
-                    if active {
-                        self.pin.set_interrupt(Trigger::RisingEdge).unwrap();
-                        self.pin
-                            .poll_interrupt(true, Some(Duration::from_millis((n * 1000.0) as u64)))
-                            .unwrap();
-                    } else {
-                        self.pin.set_interrupt(Trigger::FallingEdge).unwrap();
-                        self.pin
-                            .poll_interrupt(true, Some(Duration::from_millis((n * 1000.0) as u64)))
-                            .unwrap();
-                    }
-                }
-            }
+            let trigger = match active {
+                true => Trigger::RisingEdge,
+                false => Trigger::FallingEdge,
+            };
+            let timeout = timeout.map(|seconds| Duration::from_millis((seconds * 1000.0) as u64));
+            self.pin.set_interrupt(trigger).unwrap();
+            self.pin.poll_interrupt(true, timeout).unwrap();
         }
     };
 }
@@ -98,7 +81,6 @@ pub struct DigitalInputDevice {
     pin: InputPin,
     active_state: bool,
     inactive_state: bool,
-    bounce_time: Option<f32>,
 }
 
 impl DigitalInputDevice {
@@ -120,7 +102,6 @@ impl DigitalInputDevice {
                     pin: pin.into_input_pulldown(),
                     active_state: true,
                     inactive_state: false,
-                    bounce_time: None,
                 },
             },
         }
@@ -131,7 +112,7 @@ impl DigitalInputDevice {
     /// # Arguments
     ///
     /// * `pin` - The GPIO pin which the device is attached to
-    ///  
+    ///
     pub fn new_with_pullup(pin: u8) -> DigitalInputDevice {
         match Gpio::new() {
             Err(e) => panic!("{:?}", e),
@@ -141,7 +122,6 @@ impl DigitalInputDevice {
                     pin: pin.into_input_pullup(),
                     active_state: false,
                     inactive_state: true,
-                    bounce_time: None,
                 },
             },
         }
@@ -168,12 +148,9 @@ impl DigitalInputDevice {
 /// Alternatively, connect one side of the button to the 3V3 pin, and the other to any GPIO pin,
 /// and then create a Button instance with Button::new_with_pulldown
 pub struct Button {
-    pin: InputPin,
+    pub(crate) pin: InputPin,
     active_state: bool,
     inactive_state: bool,
-    // FIXME: Implement debouncing
-    #[allow(dead_code)]
-    bounce_time: Option<f32>,
 }
 
 impl Button {
@@ -188,7 +165,6 @@ impl Button {
                     pin: pin.into_input_pullup(),
                     active_state: false,
                     inactive_state: true,
-                    bounce_time: None,
                 },
             },
         }
@@ -204,7 +180,6 @@ impl Button {
                     pin: pin.into_input_pulldown(),
                     active_state: true,
                     inactive_state: false,
-                    bounce_time: None,
                 },
             },
         }
@@ -225,5 +200,38 @@ impl Button {
     /// * `timeout` - Number of seconds to wait before proceeding. If this is None, then wait indefinitely until the device is active.
     pub fn wait_for_press(&mut self, timeout: Option<f32>) {
         self.wait_for(timeout, true)
+    }
+
+    /// Invokes the passed closure everytime the button is pressed
+    pub fn when_pressed<C>(&mut self, action: C) -> Result<(), gpio::Error>
+    where
+        C: FnMut(Level) + Send + 'static,
+    {
+        self.action_on(true, action)
+    }
+
+    /// Invokes the passed closure everytime the button is released
+    pub fn when_released<C>(&mut self, action: C) -> Result<(), gpio::Error>
+    where
+        C: FnMut(Level) + Send + 'static,
+    {
+        self.action_on(false, action)
+    }
+
+    /// Adds an async interrupt for the corresponding trigger type to support `when_pressed`/`when_released`
+    pub(crate) fn action_on<C>(&mut self, active: bool, action: C) -> Result<(), gpio::Error>
+    where
+        C: FnMut(Level) + Send + 'static,
+    {
+        let trigger = match active {
+            true => Trigger::RisingEdge,
+            false => Trigger::FallingEdge,
+        };
+        self.pin.set_async_interrupt(trigger, action)
+    }
+
+    /// Removes all previously configured async trigger(s) (E.g. `when_pressed`/`when_released`)
+    pub fn clear_async_interrupt(&mut self) -> Result<(), gpio::Error> {
+        self.pin.clear_async_interrupt()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,3 +37,6 @@ pub mod devices;
 pub mod output_devices;
 #[macro_use]
 pub mod input_devices;
+
+mod debounce;
+pub use debounce::{Debounce, Debounced};


### PR DESCRIPTION
## Implementing debounce

- Adds `Debounced` wrapper struct for `Button` to allow calling of sync/async interrupt functions with software debouncing
- Adds `Debounce` trait to extend `Button` with `debounce()` method (returns `Debounced` wrapper struct)
- When waiting for press, check the `Debounced::last_trigger` field and make sure at least the debounce Duration has passed

## Tested with a simple program using a relatively high debounce (500ms):

```
use std::time::{Duration, Instant};

use rust_gpiozero::{Button, LED};

fn main() {
    let mut button = Button::new(4).debounce(Duration::from_millis(500));
    let mut led = LED::new(17);
    led.set_blink_count(1);
    let mut last_press = Instant::now();

    println!("Waiting for press...");
    loop {
        button.wait_for_press(None);
        println!("{}ms since last press", last_press.elapsed().as_millis());
        last_press = Instant::now();
        led.blink(0.5, 0.1);
    }
}
```

Which produces the following results when I press the button as fast as possible:

```
Waiting for press...
2074ms since last press
598ms since last press
513ms since last press
561ms since last press
566ms since last press
508ms since last press
```