### PR TITLE
Remove unused [badges] from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,3 @@ edition = "2018"
 [dependencies]
 rppal = "0.12.0"
 
-[badges]
-travis-ci = { repository = "rahul-thakoor/rust_gpiozero", branch = "master" }
-


### PR DESCRIPTION
Justification from the [[badges] section](https://doc.rust-lang.org/cargo/reference/manifest.html#the-badges-section) of the Cargo book:
> Note: crates.io previously displayed badges next to a crate on its website, but that functionality has been removed. Packages should place badges in its README file which will be displayed on crates.io

Given the above and since the GH Actions badge is now in the README, these (outdated) lines can be removed from `Cargo.toml`