### PR TITLE
Add Servo detach implementation

### DIFF
--- a/src/output_devices.rs
+++ b/src/output_devices.rs
@@ -794,4 +794,14 @@ impl Servo {
     pub fn get_frame_width(&mut self) -> u64 {
         self.frame_width
     }
+
+    pub fn detach(&mut self) {
+         if self
+            .pin
+            .clear_pwm()
+            .is_err()
+        {
+            println!("Failed to detach servo")
+        }
+   }
 }

--- a/src/output_devices.rs
+++ b/src/output_devices.rs
@@ -734,6 +734,29 @@ impl Servo {
         }
     }
 
+    /// Set servo to any position between min and max.
+    /// value must be between -1 (the minimun position) and +1 (the maximum position).
+    pub fn set_position(&mut self, value: f64) {
+        if value >= -1.0 && value <= 1.0 {
+            // Map value form [-1, 1] to [min_pulse_width, max_pulse_width] linearly
+            let range: f64 = (self.max_pulse_width - self.min_pulse_width) as f64;
+            let pulse_width: u64 = self.min_pulse_width + (((value + 1.0)/2.0) * range).round() as u64;
+            if self
+                .pin
+                .set_pwm(
+                    Duration::from_millis(self.frame_width),
+                    Duration::from_micros(pulse_width),
+                )
+                .is_err()
+            {
+                println!("Failed to set servo to a new position");
+            }
+        }
+        else {
+            println!("set_position value must be between -1 and 1");
+        }
+    }
+ 
     /// Set the servo's minimum pulse width
     pub fn set_min_pulse_width(&mut self, value: u64) {
         if value >= self.max_pulse_width {


### PR DESCRIPTION
This change adds a `detach()` method to the `Servo` class, which allows the servo to be "stopped". This can be important for software-PCM-controlled servos and for minimising CPU usage.

For comparison with the equivalent implementation in the Python GPIO Zero implementation, see the relevant:
1. [documentation](https://gpiozero.readthedocs.io/en/stable/api_output.html#gpiozero.Servo.detach);
2. Python source, where [`detach`](https://github.com/gpiozero/gpiozero/blob/a0712e702ce47c09ec31788a2b059c9bb84774b8/gpiozero/output_devices.py#L1575) calls [`value.setter`](https://github.com/gpiozero/gpiozero/blob/a0712e702ce47c09ec31788a2b059c9bb84774b8/gpiozero/output_devices.py#LL1614C1-L1614C49) which calls [`RPiGPIOPin._set_frequency()`](https://github.com/gpiozero/gpiozero/blob/a0712e702ce47c09ec31788a2b059c9bb84774b8/gpiozero/pins/rpigpio.py#L197) which then finally calls [`GPIO.PWM.stop()`](https://sourceforge.net/p/raspberry-gpio-python/code/ci/default/tree/source/py_pwm.c#l135);
3. lower-level Rust source, where [`IoPin::clear_pwm()`](https://docs.rs/rppal/latest/src/rppal/gpio/pin.rs.html#162) calls `soft_pwm.stop()`.

I'd be grateful if you'd consider this for incorporation into the library. This PR builds on @RustyPro's nice #28 changes for adding a `set_position()` implementation, which I've also found to be a useful and important addition to the library.