### PR TITLE
Fix race condition when stopping blinking

### DIFF
--- a/src/output_devices.rs
+++ b/src/output_devices.rs
@@ -139,22 +139,26 @@ macro_rules! impl_digital_output_device {
                     Some(end) => {
                         for _ in 0..end {
                             if !blinking.load(Ordering::SeqCst) {
-                                device.lock().unwrap().off();
                                 break;
                             }
                             device.lock().unwrap().on();
                             thread::sleep(Duration::from_millis((on_time * 1000.0) as u64));
+                            if !blinking.load(Ordering::SeqCst) {
+                                break;
+                            }
                             device.lock().unwrap().off();
                             thread::sleep(Duration::from_millis((off_time * 1000.0) as u64));
                         }
                     }
                     None => loop {
                         if !blinking.load(Ordering::SeqCst) {
-                            device.lock().unwrap().off();
                             break;
                         }
                         device.lock().unwrap().on();
                         thread::sleep(Duration::from_millis((on_time * 1000.0) as u64));
+                        if !blinking.load(Ordering::SeqCst) {
+                            break;
+                        }
                         device.lock().unwrap().off();
                         thread::sleep(Duration::from_millis((off_time * 1000.0) as u64));
                     },
@@ -188,7 +192,6 @@ macro_rules! impl_digital_output_device {
 
         fn stop(&self) {
             self.blinking.clone().store(false, Ordering::SeqCst);
-            self.device.lock().unwrap().pin.set_low();
         }
 
         /// When ``True``, the `value` property is ``True`` when the device's


### PR DESCRIPTION
Was running into couple different race conditions when calling blink then trying to set the LED back to on. Minimal program to recreate bug :

```rust
use std::{thread, time::Duration};
use rust_gpiozero::LED;

fn main() {
    let mut led = LED::new(12);
    led.on();
    thread::sleep(Duration::from_secs(5));
    led.blink(3, 3);
    thread::sleep(Duration::from_secs(5));
    led.on();
    thread::sleep(Duration::from_secs(5));
    led.off();
}
```

Two race conditions I was hitting:
1. `led.on()` called while blinker is running; it sets the `blinking` to `false` then turns the device to on but by the time blinker wakes from sleep the device is on and it then turns it off again before bailing from its loop
2. If you call `led.on()` between the on/off sleep interval the blinker will then turn it off

The first is remediated by removing `device.lock().unwrap().off();` from the `if !blinking.load(Ordering::SeqCst){ .. }` condition and just relying on who ever calls `self.stop()` to set the final state it wants.

The second remediated by adding the `if !blinking.load(Ordering::SeqCst){ .. }` check between sleeps to avoid clobbering the state whoever called stop set (feel there might be cleaner way to do this part 😅).

 